### PR TITLE
refactor(auto-install): add condition to macOS terminal copy keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1362,7 +1362,7 @@ Open `keybindings.json` via `⇧⌘P` → **"Preferences: Open Keyboard Shortcut
     "key": "cmd+c",
     "command": "workbench.action.terminal.sendSequence",
     "args": { "text": "\u001b[99;9u" },
-    "when": "terminalFocus && isMac"
+    "when": "terminalFocus && isMac && !terminalTextSelected"
   },
   {
     "key": "cmd+v",

--- a/assets/auto-install/lib/06-terminals-vscode.sh
+++ b/assets/auto-install/lib/06-terminals-vscode.sh
@@ -148,7 +148,7 @@ configure_vscode() {
         "key": "cmd+c",
         "command": "workbench.action.terminal.sendSequence",
         "args": { "text": "\u001b[99;9u" },
-        "when": "terminalFocus && isMac"
+        "when": "terminalFocus && isMac && !terminalTextSelected"
     },
     {
         "key": "cmd+v",


### PR DESCRIPTION
This update modifies the VS Code terminal keybind for “copy” by requiring no text to be selected (`!terminalTextSelected`). This prevents conflicts when copying with default selection mechanism.